### PR TITLE
修复堆栈深度过高

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,5 +43,6 @@
     "tabbar",
     "unibest",
     "WechatMiniprogram"
-  ]
+  ],
+  "typescript.tsdk": "node_modules\\typescript\\lib"
 }


### PR DESCRIPTION
vite.config.ts 里堆栈深度过高报错
vscode工作区配置使用工作区的ts版本