### PR TITLE
fix: 微信小程序封装的http请求中的responseType不支持json，会导致请求无法回来

### DIFF
--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -7,7 +7,7 @@ export const http = <T>(options: CustomRequestOptions) => {
     uni.request({
       ...options,
       dataType: 'json',
-      responseType: 'json',
+      responseType: 'text',
       // 响应成功
       success(res) {
         // 状态码 2xx，参考 axios 的设计


### PR DESCRIPTION
详情可以查看
https://developers.weixin.qq.com/miniprogram/dev/api/network/request/wx.request.html
![image](https://github.com/codercup/unibest/assets/82896623/a1150743-1934-47d7-a9c7-69b00e998346)

如果不改成text的话
会导致开发环境下如果配置允许使用未验证过的域名之后
微信小程序请求会无法返回来