### PR TITLE
去除TypeScript Vue Plugin拓展

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "vue.volar",
-    "vue.vscode-typescript-vue-plugin",
     "stylelint.vscode-stylelint",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",


### PR DESCRIPTION
TypeScript Vue Plugin拓展已弃用，已被合并进Vue Official(Vue.volar)