### PR TITLE
fix: typings.d.ts类型无需导出

### DIFF
--- a/src/interceptors/request.ts
+++ b/src/interceptors/request.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-param-reassign */
 import qs from 'qs'
 import { useUserStore } from '@/store'
-import { IUserInfo } from '@/typings'
 
 export type CustomRequestOptions = UniApp.RequestOptions & { query?: Record<string, any> }
 

--- a/src/pages/demo/base/enum.vue
+++ b/src/pages/demo/base/enum.vue
@@ -10,8 +10,6 @@
 </template>
 
 <script lang="ts" setup>
-import { TestEnum } from '@/typings.d'
-
 type T = TestEnum.A
 const a = 'a' as T
 console.log(a)

--- a/src/pages/demo/base/request.vue
+++ b/src/pages/demo/base/request.vue
@@ -37,7 +37,6 @@
 
 <script lang="ts" setup>
 import { getFooAPI, postFooAPI, IFooItem } from '@/service/foo'
-import { IResData } from '@/typings'
 
 const recommendUrl = ref('http://laf.run/signup?code=ohaOgIX')
 

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { IUserInfo } from '../typings'
 
 const initState = { nickname: '', avatar: '' }
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,13 +1,13 @@
 /* eslint-disable no-unused-vars */
 // 全局要用的类型放到这里
 
-export type IResData<T> = {
+type IResData<T> = {
   code: number
   msg: string
   result: T
 }
 
-export type IUserInfo = {
+type IUserInfo = {
   nickname?: string
   avatar?: string
   /** 微信的 openid，非微信没有这个字段 */
@@ -15,7 +15,7 @@ export type IUserInfo = {
   token?: string
 }
 
-export enum TestEnum {
+enum TestEnum {
   A = 'a',
   B = 'b',
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,5 +1,4 @@
 import { CustomRequestOptions } from '@/interceptors/request'
-import { IResData } from '@/typings'
 
 export const http = <T>(options: CustomRequestOptions) => {
   // 1. 返回 Promise 对象


### PR DESCRIPTION
原来的写法，在App.vue中导入：
`import { IUserInfo } from '@/typings'`
会导致：
`[vite] [plugin:vite:import-analysis] Cannot find module 'C:/code/tulingzhixing/src/typings.h5' from 'C:/code/tulingzhixing/src/App.vue'`

或者
`import { IUserInfo } from './typings'`
会导致：
`[vite] [plugin:vite:import-analysis] Failed to resolve import "./typings" from "src\App.vue". Does the file exist?`

或者
`import { IUserInfo } from './typings.d'`
会导致运行时报错：
`App.vue:5 Uncaught SyntaxError: The requested module '/src/typings.d.ts' does not provide an export named 'IUserInfo' (at App.vue:5:1)`