### PR TITLE
chore: class选择器命名校验支持下划线

### DIFF
--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -49,5 +49,6 @@ module.exports = {
     'no-empty-source': null,
     'comment-no-empty': null,
     'no-duplicate-selectors': null,
+    'selector-class-pattern': '^([a-z][a-z0-9]*)[a-z0-9_-]*$',
   },
 }


### PR DESCRIPTION
在默认的kebab-case命名规则下支持下划线

```css
/deep/.uni-list-item__content-title[data-v-296a3d7e] {
  overflow: hidden;
  font-size: 30rpx;
  font-weight: 500;
  color: #333;
}

/deep/.uni-list-item__container {
  padding: 30rpx;
}
```