### PR TITLE
fix: 解决uno.css在写hex颜色功能不支持高亮等问题

### DIFF
--- a/uno.config.ts
+++ b/uno.config.ts
@@ -1,6 +1,8 @@
 // uno.config.ts
 import {
-  Preset,
+  type Preset,
+  type SourceCodeTransformer,
+  presetUno,
   defineConfig,
   presetAttributify,
   presetIcons,
@@ -18,25 +20,24 @@ import {
 // @see https://unocss.dev/presets/legacy-compat
 import presetLegacyCompat from '@unocss/preset-legacy-compat'
 
-const isH5 = process.env?.UNI_PLATFORM === 'h5'
 const isMp = process.env?.UNI_PLATFORM?.startsWith('mp') ?? false
 
 const presets: Preset[] = []
-if (!isMp) {
-  /**
-   * you can add `presetAttributify()` here to enable unocss attributify mode prompt
-   * although preset is not working for applet, but will generate useless css
-   * 为了不生产无用的css,要过滤掉 applet
-   */
-  // 支持css class属性化，eg: `<button bg="blue-400 hover:blue-500 dark:blue-500 dark:hover:blue-600" text="sm white">attributify Button</button>`
-  presets.push(presetAttributify())
-}
-if (!isH5) {
-  presets.push(presetRemRpx())
+const transformers: SourceCodeTransformer[] = []
+if (isMp) {
+  // 使用小程序预设
+  presets.push(presetApplet(), presetRemRpx())
+  transformers.push(transformerApplet())
+} else {
+  presets.push(
+    // 非小程序用官方预设
+    presetUno(),
+    // 支持css class属性化
+    presetAttributify(),
+  )
 }
 export default defineConfig({
   presets: [
-    presetApplet({ enable: !isH5 }),
     ...presets,
     // 支持图标，需要搭配图标库，eg: @iconify-json/carbon, 使用 `<button class="i-carbon-sun dark:i-carbon-moon" />`
     presetIcons({
@@ -60,6 +61,7 @@ export default defineConfig({
    */
   shortcuts: [['center', 'flex justify-center items-center']],
   transformers: [
+    ...transformers,
     // 启用 @apply 功能
     transformerDirectives(),
     // 启用 () 分组功能
@@ -71,7 +73,6 @@ export default defineConfig({
       prefixedOnly: true,
       prefix: 'fg',
     }),
-    transformerApplet(),
   ],
   rules: [
     [


### PR DESCRIPTION
目前这个写法不高亮，写了是有效的，修改后得重启
![image](https://github.com/codercup/unibest/assets/44717504/b7e79a80-d1a4-4690-a761-4d833cc1bc45)
以下这种写法是不支持也没有高亮的
![image](https://github.com/codercup/unibest/assets/44717504/57f317f4-7696-4b93-82ed-1817e0af74bd)

使用我的调整修改uno.cs配置文件就好啦！
