### PR TITLE
fix(eslint): 函数重载飘红

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -69,6 +69,9 @@ module.exports = {
     'no-unused-vars': 'off',
     'no-param-reassign': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
+    // 避免 `eslint` 对于 `typescript` 函数重载的误报
+    'no-redeclare': 'off',
+    '@typescript-eslint/no-redeclare': 'error',
   },
   // eslint-import-resolver-typescript 插件，@see https://www.npmjs.com/package/eslint-import-resolver-typescript
   settings: {


### PR DESCRIPTION
# 问题描述
在JavaScript中，不支持函数重载，因此如果在代码中定义多个同名函数，eslint会误认为是重复定义，从而触发[no-redeclare](https://link.juejin.cn/?target=https%3A%2F%2Feslint.org%2Fdocs%2Frules%2Fno-redeclare)规则报错。然而在TypeScript中，函数重载仅作为一种静态类型的校验工具，是可以存在的。详见：[Function Overloads](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads)。

# 解决方案
为了绕开eslint在TypeScript中对函数重载的误报，可以参考[no-redeclare](https://typescript-eslint.io/rules/no-redeclare/)文档, 这是我的解决方法：
`.eslintrc.cjs`文件中添加
```javascript
// .eslintrc.cjs
module.exports = {
  "rules": {
    // 关闭 eslint 的 no-redeclare 规则
    "no-redeclare": "off",
    // 使用 @typescript-eslint 的 no-redeclare 规则替代
    "@typescript-eslint/no-redeclare": "error"
  }
};
```
- `eslint`不会再对函数重载报`no-redeclare`的错误。
![image](https://github.com/codercup/unibest/assets/52315768/633289c6-f5d6-4a91-8a4b-5a2d0217c480)
- 并且能正确提示重复定义错误。
![image](https://github.com/codercup/unibest/assets/52315768/068c0f78-9ad3-46aa-8865-453f841e40ad)