### PR TITLE
增强 useRequest 钩子 

### DIFF
--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -3,8 +3,6 @@ import { UnwrapRef } from 'vue'
 type IUseRequestOptions<T> = {
   /** 是否立即执行，如果是则在onLoad执行 */
   immediate?: boolean
-  /** 是否保证立即执行，如果是则在钩子调用时立即执行 */
-  ensureImmediate?: boolean
   /** 初始化数据 */
   initialData?: T
 }
@@ -12,35 +10,14 @@ type IUseRequestOptions<T> = {
 /**
  * useRequest是一个定制化的请求钩子，用于处理异步请求和响应。
  * @param func 一个执行异步请求的函数，返回一个包含响应数据的Promise。
- * @param options 包含请求选项的对象 {immediate, ensureImmediate， initialData}。
- * @param options.immediate 是否立即执行，如果是则在onLoad执行，默认为true。
- * @param options.ensureImmediate 是否保证立即执行，如果是则在钩子调用时立即执行，默认为false。
+ * @param options 包含请求选项的对象 {immediate, initialData}。
+ * @param options.immediate 是否立即执行请求，默认为true。
  * @param options.initialData 初始化数据，默认为undefined。
  * @returns 返回一个对象{loading, error, data, run}，包含请求的加载状态、错误信息、响应数据和手动触发请求的函数。
- * @example
- * 1. 默认在组件挂载后立即执行请求：
- *
- * const { loading, error, data, run } = useRequest(() => apiCall());
- *
- * 2. 钩子调用时立即执行执行请求：
- *
- * const { loading, error, data, run } = useRequest(() => apiCall(), { ensureImmediate: true });
- *
- * 3. 不在组件挂载后立即执行请求，需要手动触发：
- *
- * const { loading, error, data, run } = useRequest(() => apiCall(), { immediate: false });
- * onMounted(() => {
- *   run();
- * });
- *
- * 注意事项：
- * - `immediate` 参数控制请求是否在组件挂载后立即执行。适用于需要在组件挂载后立即执行请求的场景。
- * - `ensureImmediate` 参数确保请求在钩子调用时立即执行，不管 `immediate` 的值。适合无条件立即执行请求的场景。
- * - 当同时设置 `immediate: false` 和 `ensureImmediate: true` 时，请求仍会立即执行。
  */
 export default function useRequest<T>(
   func: () => Promise<IResData<T>>,
-  options: IUseRequestOptions<T> = { immediate: true, ensureImmediate: false },
+  options: IUseRequestOptions<T> = { immediate: true },
 ) {
   const loading = ref(false)
   const error = ref(false)
@@ -62,12 +39,8 @@ export default function useRequest<T>(
       })
   }
 
-  if (options.ensureImmediate) {
-    // 钩子调用时立即执行执行请求
-    run()
-  } else if (options.immediate) {
-    // 组件挂载后立即执行请求
-    onLoad(() => run())
-  }
+  onLoad(() => {
+    options.immediate && run()
+  })
   return { loading, error, data, run }
 }

--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -12,7 +12,7 @@ type IUseRequestOptions<T> = {
 /**
  * useRequest是一个定制化的请求钩子，用于处理异步请求和响应。
  * @param func 一个执行异步请求的函数，返回一个包含响应数据的Promise。
- * @param options 包含请求选项的对象 {immediate, initialData}。
+ * @param options 包含请求选项的对象 {immediate, ensureImmediate， initialData}。
  * @param options.immediate 是否立即执行，如果是则在onLoad执行，默认为true。
  * @param options.ensureImmediate 是否保证立即执行，如果是则在钩子调用时立即执行，默认为false。
  * @param options.initialData 初始化数据，默认为undefined。
@@ -35,7 +35,7 @@ type IUseRequestOptions<T> = {
  *
  * 注意事项：
  * - `immediate` 参数控制请求是否在组件挂载后立即执行。适用于需要在组件挂载后立即执行请求的场景。
- * - `ensureImmediate` 参数强制请求在组件挂载后立即执行，不管 `immediate` 的值。这在需要无条件立即执行请求的场景中非常有用。
+ * - `ensureImmediate` 参数确保请求在钩子调用时立即执行，不管 `immediate` 的值。适合无条件立即执行请求的场景。
  * - 当同时设置 `immediate: false` 和 `ensureImmediate: true` 时，请求仍会立即执行。
  */
 export default function useRequest<T>(

--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -3,6 +3,8 @@ import { UnwrapRef } from 'vue'
 type IUseRequestOptions<T> = {
   /** 是否立即执行，如果是则在onLoad执行 */
   immediate?: boolean
+  /** 是否保证立即执行，如果是则在钩子调用时立即执行 */
+  ensureImmediate?: boolean
   /** 初始化数据 */
   initialData?: T
 }
@@ -11,13 +13,34 @@ type IUseRequestOptions<T> = {
  * useRequest是一个定制化的请求钩子，用于处理异步请求和响应。
  * @param func 一个执行异步请求的函数，返回一个包含响应数据的Promise。
  * @param options 包含请求选项的对象 {immediate, initialData}。
- * @param options.immediate 是否立即执行请求，默认为true。
+ * @param options.immediate 是否立即执行，如果是则在onLoad执行，默认为true。
+ * @param options.ensureImmediate 是否保证立即执行，如果是则在钩子调用时立即执行，默认为false。
  * @param options.initialData 初始化数据，默认为undefined。
  * @returns 返回一个对象{loading, error, data, run}，包含请求的加载状态、错误信息、响应数据和手动触发请求的函数。
+ * @example
+ * 1. 默认在组件挂载后立即执行请求：
+ *
+ * const { loading, error, data, run } = useRequest(() => apiCall());
+ *
+ * 2. 钩子调用时立即执行执行请求：
+ *
+ * const { loading, error, data, run } = useRequest(() => apiCall(), { ensureImmediate: true });
+ *
+ * 3. 不在组件挂载后立即执行请求，需要手动触发：
+ *
+ * const { loading, error, data, run } = useRequest(() => apiCall(), { immediate: false });
+ * onMounted(() => {
+ *   run();
+ * });
+ *
+ * 注意事项：
+ * - `immediate` 参数控制请求是否在组件挂载后立即执行。适用于需要在组件挂载后立即执行请求的场景。
+ * - `ensureImmediate` 参数强制请求在组件挂载后立即执行，不管 `immediate` 的值。这在需要无条件立即执行请求的场景中非常有用。
+ * - 当同时设置 `immediate: false` 和 `ensureImmediate: true` 时，请求仍会立即执行。
  */
 export default function useRequest<T>(
   func: () => Promise<IResData<T>>,
-  options: IUseRequestOptions<T> = { immediate: true },
+  options: IUseRequestOptions<T> = { immediate: true, ensureImmediate: false },
 ) {
   const loading = ref(false)
   const error = ref(false)
@@ -39,8 +62,12 @@ export default function useRequest<T>(
       })
   }
 
-  onLoad(() => {
-    options.immediate && run()
-  })
+  if (options.ensureImmediate) {
+    // 钩子调用时立即执行执行请求
+    run()
+  } else if (options.immediate) {
+    // 组件挂载后立即执行请求
+    onLoad(() => run())
+  }
   return { loading, error, data, run }
 }

--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -1,7 +1,7 @@
 import { UnwrapRef } from 'vue'
 
 type IUseRequestOptions<T> = {
-  /** 是否立即执行，如果是则在onLoad执行 */
+  /** 是否立即执行 */
   immediate?: boolean
   /** 初始化数据 */
   initialData?: T
@@ -11,13 +11,13 @@ type IUseRequestOptions<T> = {
  * useRequest是一个定制化的请求钩子，用于处理异步请求和响应。
  * @param func 一个执行异步请求的函数，返回一个包含响应数据的Promise。
  * @param options 包含请求选项的对象 {immediate, initialData}。
- * @param options.immediate 是否立即执行请求，默认为true。
+ * @param options.immediate 是否立即执行请求，默认为false。
  * @param options.initialData 初始化数据，默认为undefined。
  * @returns 返回一个对象{loading, error, data, run}，包含请求的加载状态、错误信息、响应数据和手动触发请求的函数。
  */
 export default function useRequest<T>(
   func: () => Promise<IResData<T>>,
-  options: IUseRequestOptions<T> = { immediate: true },
+  options: IUseRequestOptions<T> = { immediate: false },
 ) {
   const loading = ref(false)
   const error = ref(false)
@@ -39,8 +39,6 @@ export default function useRequest<T>(
       })
   }
 
-  onLoad(() => {
-    options.immediate && run()
-  })
+  options.immediate && run()
   return { loading, error, data, run }
 }

--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -24,13 +24,15 @@ export default function useRequest<T>(
   const data = ref<T>(options.initialData)
   const run = async () => {
     loading.value = true
-    func()
+    return func()
       .then((res) => {
         data.value = res.data as UnwrapRef<T>
         error.value = false
+        return data.value
       })
       .catch((err) => {
         error.value = err
+        throw err
       })
       .finally(() => {
         loading.value = false

--- a/src/pages/about/components/request.vue
+++ b/src/pages/about/components/request.vue
@@ -47,6 +47,7 @@ const recommendUrl = ref('http://laf.run/signup?code=ohaOgIX')
 const initialData = undefined
 // 适合少部分全局性的接口————多个页面都需要的请求接口，额外编写一个 Service 层
 const { loading, error, data, run } = useRequest<IFooItem>(() => getFooAPI('菲鸽'), {
+  immediate: true,
   initialData,
 })
 const reset = () => {


### PR DESCRIPTION
### Commit 1: 增加返回值和错误处理

- 在 `run` 函数中增加 `return func()`，确保 `run` 函数返回的Promise对象的结果由 `func` 函数返回结果决定。
- 在 `run` 函数中添加 `return data.value`，以便请求成功时返回响应数据。此时 `run` 函数返回的Promise状态为resolved，value为`data.value`。
- 在 `run` 函数中添加 `throw err`，以便请求失败时抛出错误。此时 `run` 函数返回的Promise状态为rejected，reason则为抛出的异常。

在需要同步处理数据或者错误情况下，可以直接访问请求结果，并使用 `try...catch` 来处理错误。不必监听data和error，从而提高 `useRequest` 钩子的可用性和健壮性。

示例：

```typescript
const { run } = useRequest(fetchData, { immediate: false })

try {
  const result = await run()
  console.log('成功:', result)
} catch (err) {
  console.error('失败:', err)
}
```

### Commit 2: 增加 ensureImmediate 选项以避免生命周期钩子错误

- 新增 `ensureImmediate` 选项，该选项默认为`false`，实现在钩子调用时立即执行请求的需求。
- 如果 `ensureImmediate` 为 `true`，在钩子调用时立即执行 `run` 函数。
- 保持 `immediate` 选项在 `onLoad` 中执行请求。

这些更改可以避免在 `setup` 函数之外使用钩子时出现的 `onLoad` 只能在 `setup` 内使用的错误(`Lifecycle injection APIs can only be used during execution of setup()`)，确保请求能够在钩子调用时立即执行。
> 其他解决方法是将 `immediate` 设置为 `false`，然后手动调用 `run`，但我觉得这样比较麻烦，所以增加了一个 `ensureImmediate` 选项。

示例：
- 修改前
```typescript
const funcNotInSetup = () => {
  const { run } = useRequest(fetchData)
}
```
> 触发警告，fetchData函数不执行
> [Vue warn]: onLoad is called when there is no active component instance to be associated with. Lifecycle injection APIs canonly be used during execution of setup(). If you are using async setup(), make sure to register lifecycle hooks before the first await statement.

- 不修改的解决方式
```typescript
const funcNotInSetup = () => {
  const { run } = useRequest(fetchData, , { immediate: false })
  run()
}
```
> 需求是立即执行，但要弯绕一下，体验差

- 修改后
```typescript
const funcNotInSetup = () => {
  const { run } = useRequest(fetchData, , { ensureImmediate: true})
}
```