### PR TITLE
也许可以把 esbuild 安装至可选依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,8 +104,6 @@
     "@dcloudio/uni-cli-shared": "3.0.0-alpha-4010520240507001",
     "@dcloudio/uni-stacktracey": "3.0.0-alpha-4010520240507001",
     "@dcloudio/vite-plugin-uni": "3.0.0-alpha-4010520240507001",
-    "@esbuild/darwin-arm64": "0.20.2",
-    "@esbuild/darwin-x64": "0.20.2",
     "@iconify-json/carbon": "^1.1.35",
     "@rollup/rollup-darwin-x64": "^4.18.0",
     "@types/node": "^20.14.2",
@@ -150,5 +148,12 @@
     "vite": "5.2.8",
     "vite-plugin-restart": "^0.4.0",
     "vue-tsc": "^1.8.27"
+  },
+  "optionalDependencies": {
+    "@esbuild/darwin-arm64": "0.21.5",
+    "@esbuild/darwin-x64": "0.21.5",
+    "@esbuild/linux-x64": "0.21.5"
+    "@esbuild/win32-x64": "0.21.5"
   }
+
 }


### PR DESCRIPTION
把 esbuild 安装至可选依赖，在不同平台自动匹配，避免发生不必要的错误，与🙀。跟舒服的安装依赖包