### PR TITLE
feat: 请求拦截器增强：动态配置baseUrl，以适应小程序不同环境。

### DIFF
--- a/src/interceptors/request.ts
+++ b/src/interceptors/request.ts
@@ -1,13 +1,14 @@
 /* eslint-disable no-param-reassign */
 import qs from 'qs'
 import { useUserStore } from '@/store'
+import { getEvnBaseUrl } from '@/utils'
 
 export type CustomRequestOptions = UniApp.RequestOptions & {
   query?: Record<string, any>
 } & IUniUploadFileOptions // 添加uni.uploadFile参数类型
 
 // 请求基地址
-const baseURL = import.meta.env.VITE_SERVER_BASEURL
+const baseURL = getEvnBaseUrl()
 
 // 拦截器配置
 const httpInterceptor = {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 import pagesJson from '@/pages.json'
+import { isMp } from './platform'
 
 console.log(pagesJson)
 
@@ -110,4 +111,33 @@ export const getArrElementByIdx = (arr: any[], index: number) => {
   if (index < 0) return arr[arr.length + index]
   if (index >= arr.length) return undefined
   return arr[index]
+}
+
+/**
+ * 根据微信小程序当前环境，判断应该获取的BaseUrl
+ */
+export const getEvnBaseUrl = () => {
+  // 请求基准地址
+  let baseUrl = import.meta.env.VITE_SERVER_BASEURL
+
+  // 小程序端环境区分
+  if (isMp) {
+    const {
+      miniProgram: { envVersion },
+    } = uni.getAccountInfoSync()
+
+    switch (envVersion) {
+      case 'develop':
+        baseUrl = 'https://dev.yyb.happydo.net'
+        break
+      case 'trial':
+        baseUrl = 'https://dev.yyb.happydo.net'
+        break
+      case 'release':
+        baseUrl = 'https://yyb.happydo.net'
+        break
+    }
+  }
+
+  return baseUrl
 }


### PR DESCRIPTION
在请求拦截器中，实现了一个新的功能，通过新创建的工具函数`getEvnBaseUrl`动态获取请求的baseUrl。这将使得在微信小程序的不同环境中（开发、体验和正式）请求正确的服务器地址。变更包括调整baseUrl的赋值方式，并在`request.ts`中使用这个新函数。

同时，进行了一个微调，调整了`index.ts`中获取页面json信息的方式，虽然这并不影响功能，但对代码结构产生了一点影响。