### PR TITLE
Update package.json 固定sass版本号，解决sass@1.8版本后@import已弃用警告问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "postcss-html": "^1.7.0",
     "postcss-scss": "^4.0.9",
     "rollup-plugin-visualizer": "^5.12.0",
-    "sass": "^1.77.5",
+    "sass": "1.77.5",
     "stylelint": "^16.6.1",
     "stylelint-config-html": "^1.1.0",
     "stylelint-config-recess-order": "^4.6.0",


### PR DESCRIPTION
fix:固定sass版本号，解决sass@1.8版本后@import已弃用警告问题